### PR TITLE
Move the compilation to when we create the cpu device

### DIFF
--- a/WxFactory
+++ b/WxFactory
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from compiler.compiler_module import build_librairies
-
 """ The WxFactory model """
 
 import argparse
@@ -19,19 +17,6 @@ def main():
 
     args = None
     rank = MPI.COMM_WORLD.rank
-
-    build_error = False
-    if rank == 0:
-        try:
-            build_librairies()
-        except e:
-            build_error = e
-   
-    MPI.COMM_WORLD.bcast(build_error, root=0)
-    if build_error:
-        if rank == 0:
-            raise build_error
-        sys.exit(-1)
 
     if rank == 0:
         print(f'Start time : {datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")}')

--- a/common/simulation.py
+++ b/common/simulation.py
@@ -119,9 +119,16 @@ class Simulation:
          except ValueError:
             if self.rank == 0:
                print(f'Unable to create a CudaDevice, will revert to CPU')
+               
+            from compiler.compiler_module import build_librairies_mpi
+            build_librairies_mpi()
+
             device = CpuDevice()
 
       else:
+         from compiler.compiler_module import build_librairies_mpi
+         build_librairies_mpi()
+         
          device = CpuDevice()
 
       return device

--- a/compiler/compiler_module.py
+++ b/compiler/compiler_module.py
@@ -119,3 +119,21 @@ def build_librairies(force_build: bool = False):
 
         for interface_to_copy in interfaces_to_copy_for_intellisense:
             shutil.copyfile(interface_to_copy, os.path.join(library_directory, interface_to_copy))
+
+def build_librairies_mpi():
+    from mpi4py import MPI
+
+    rank = MPI.COMM_WORLD.rank
+    
+    build_error = False
+    if rank == 0:
+        try:
+            build_librairies()
+        except Exception as e:
+            build_error = e
+   
+    MPI.COMM_WORLD.bcast(build_error, root=0)
+    if build_error:
+        if rank == 0:
+            raise build_error
+        sys.exit(-1)


### PR DESCRIPTION
Move the compilation process to when we create the cpu device to not compile c++ code if we use cupy.

Bouger le processus de compilation à quand on créer le device cpu pour ne pas compiler le code c++ si on utilse cupy.